### PR TITLE
Adjust the pipeline to the latest changes for Salt Bundle projects

### DIFF
--- a/Jenkinsfile_promote_salt_bundle_packages
+++ b/Jenkinsfile_promote_salt_bundle_packages
@@ -65,7 +65,6 @@ pipeline {
                 sh "osc copypac systemsmanagement:saltstack:bundle:testing:debbuild perl-Try-Tiny systemsmanagement:saltstack:bundle:debbuild"
                 sh "osc copypac systemsmanagement:saltstack:bundle:testing:debbuild perl-UNIVERSAL-require systemsmanagement:saltstack:bundle:debbuild"
                 sh "osc copypac systemsmanagement:saltstack:bundle:testing:debbuild perl-parent systemsmanagement:saltstack:bundle:debbuild"
-                sh "osc copypac systemsmanagement:saltstack:bundle:testing:debbuild perl-version systemsmanagement:saltstack:bundle:debbuild"
             }
         }
 

--- a/Jenkinsfile_promote_salt_bundle_packages
+++ b/Jenkinsfile_promote_salt_bundle_packages
@@ -138,10 +138,10 @@ pipeline {
                 sh "osc copypac systemsmanagement:saltstack:bundle:testing saltbundlepy-zypp-plugin systemsmanagement:saltstack:bundle"
 
                 echo "Promote dependencies for Salt bundle in AlmaLinux8"
-                sh "osc copypac systemsmanagement:saltstack:bundle:testing:AlmaLinux8 fdupes systemsmanagement:saltstack:bundle:AlmaLinux8"
+                echo "-- nothing to promote --"
 
                 echo "Promote dependencies for Salt bundle in CentOS7"
-                sh "osc copypac systemsmanagement:saltstack:bundle:testing:CentOS7 fdupes systemsmanagement:saltstack:bundle:CentOS7"
+                echo "-- nothing to promote --"
 
                 echo "Promote dependencies for Salt bundle in CentOS8"
                 echo "-- nothing to promote --"

--- a/Jenkinsfile_promote_salt_bundle_packages
+++ b/Jenkinsfile_promote_salt_bundle_packages
@@ -140,6 +140,9 @@ pipeline {
                 echo "Promote dependencies for Salt bundle in AlmaLinux8"
                 echo "-- nothing to promote --"
 
+                echo "Promote dependencies for Salt bundle in AlmaLinux9"
+                echo "-- nothing to promote --"
+
                 echo "Promote dependencies for Salt bundle in CentOS7"
                 echo "-- nothing to promote --"
 
@@ -205,6 +208,9 @@ pipeline {
 
                 echo "Promote project config for AlmaLinux8 subproject"
                 sh "osc meta prjconf systemsmanagement:saltstack:bundle:testing:AlmaLinux8 | osc meta prjconf --file='-' systemsmanagement:saltstack:bundle:AlmaLinux8"
+
+                echo "Promote project config for AlmaLinux9 subproject"
+                sh "osc meta prjconf systemsmanagement:saltstack:bundle:testing:AlmaLinux9 | osc meta prjconf --file='-' systemsmanagement:saltstack:bundle:AlmaLinux9"
 
                 echo "Promote project config for CentOS7 subproject"
                 sh "osc meta prjconf systemsmanagement:saltstack:bundle:testing:CentOS7 | osc meta prjconf --file='-' systemsmanagement:saltstack:bundle:CentOS7"


### PR DESCRIPTION
This PR contains the following adjustments:
1. Removes `perl-version` from `debbuil` subprojects, as the package was deleted in the Factory and substituted with `perl`
2. Removes `fdupes` from promotion for `AlmaLinux8` and `CentOS7` subprojects as actually `fdups` is a link to `SUSE:SLE-15...`, no need to promote it.
3. Adds `AlmaLinux9` with the empty package list, with only `prjconf` promotion for it.