### PR TITLE
Improve promotion script and pipelines

### DIFF
--- a/Jenkinsfile_promote_salt_bundle_packages
+++ b/Jenkinsfile_promote_salt_bundle_packages
@@ -27,7 +27,7 @@ pipeline {
 
         stage('Promote Salt Bundle dependency packages and project configurations for Salt Bundle subprojects') {
             steps {
-                sh 'python3 promote_packages.py systemsmanagement:saltstack:bundle:testing systemsmanagement:saltstack:bundle'
+                sh 'python3 promote_packages.py -s systemsmanagement:saltstack:bundle:testing -t systemsmanagement:saltstack:bundle'
             }
         }
     }

--- a/Jenkinsfile_promote_salt_bundle_packages
+++ b/Jenkinsfile_promote_salt_bundle_packages
@@ -35,7 +35,7 @@ pipeline {
         stage('Promote Salt bundle dependencies packages') {
             steps {
                 echo 'Promote general Salt bundle dependencies packages from "systemsmanagement:saltstack:bundle:testing" to "systemsmanagement:saltstack:bundle"'
-                sh 'python3 promote_packages.py -s systemsmanagement:saltstack:bundle:testing -t systemsmanagement:saltstack:bundle packages'
+                sh 'python3 promote_packages.py -s systemsmanagement:saltstack:bundle:testing -t systemsmanagement:saltstack:bundle --exclude venv-salt-minion packages'
                 echo 'Promote Salt bundle dependencies packages for different OSes'
                 sh 'python3 promote_packages.py -s systemsmanagement:saltstack:bundle:testing -t systemsmanagement:saltstack:bundle --exclude-subproject systemsmanagement:saltstack:bundle:testing:debbuild subprojects'
             }

--- a/Jenkinsfile_promote_salt_bundle_packages
+++ b/Jenkinsfile_promote_salt_bundle_packages
@@ -25,9 +25,33 @@ pipeline {
             }
         }
 
-        stage('Promote Salt Bundle dependency packages and project configurations for Salt Bundle subprojects') {
+        stage('Promote debbuild packages for building Salt bundle') {
             steps {
-                sh 'python3 promote_packages.py -s systemsmanagement:saltstack:bundle:testing -t systemsmanagement:saltstack:bundle'
+                echo 'Promote debbuild package from "systemsmanagement:saltstack:bundle:testing:debbuild" to "systemsmanagement:saltstack:bundle:debbuild"'
+                sh 'python3 promote_packages.py -s systemsmanagement:saltstack:bundle:testing:debbuild -t systemsmanagement:saltstack:bundle:debbuild packages'
+            }
+        }
+
+        stage('Promote Salt bundle dependencies packages') {
+            steps {
+                echo 'Promote general Salt bundle dependencies packages from "systemsmanagement:saltstack:bundle:testing" to "systemsmanagement:saltstack:bundle"'
+                sh 'python3 promote_packages.py -s systemsmanagement:saltstack:bundle:testing -t systemsmanagement:saltstack:bundle packages'
+                echo 'Promote Salt bundle dependencies packages for different OSes'
+                sh 'python3 promote_packages.py -s systemsmanagement:saltstack:bundle:testing -t systemsmanagement:saltstack:bundle --exclude-subproject systemsmanagement:saltstack:bundle:testing:debbuild subprojects'
+            }
+        }
+
+        stage('Promote Project Configs for Salt bundle subprojects') {
+            steps {
+                echo "Promote project configs for subprojects at 'systemsmanagement:saltstack:bundle:testing' to 'systemsmanagement:saltstack:bundle'"
+                sh 'python3 promote_packages.py -s systemsmanagement:saltstack:bundle:testing -t systemsmanagement:saltstack:bundle projectconfigs'
+            }
+        }
+
+        stage('Promote Salt bundle main package (venv-salt-minion)') {
+            steps {
+                echo 'Promote Salt bundle package (venv-salt-minion) from "systemsmanagement:saltstack:bundle:testing" to "systemsmanagement:saltstack:bundle"'
+                sh "osc copypac systemsmanagement:saltstack:bundle:testing venv-salt-minion systemsmanagement:saltstack:bundle"
             }
         }
     }

--- a/Jenkinsfile_promote_salt_packages
+++ b/Jenkinsfile_promote_salt_packages
@@ -9,41 +9,83 @@ properties([
 pipeline {
 
     parameters {
-        string(defaultValue: '3004', description: 'Salt version to promote from products:testing to products.', name: 'salt_version')
-        string(defaultValue: '', description: 'SUSE Manager maintenance update version that this Salt update is released with, e.g. 4.1.7', name: 'mu_version')
+        string(defaultValue: '3006.0', description: 'Salt version to promote from products:testing to products.', name: 'salt_version')
+        string(defaultValue: '', description: 'SUSE Manager maintenance update version that this Salt update is released with, e.g. 4.3.7', name: 'mu_version')
+        booleanParam(name: 'recreate_salt_mu_branches', defaultValue: false, description: 'Advanced: Uncheck this if you want to recreate the already existing MU branches at "openSUSE/salt" repository')
     }
 
     agent { label 'manager-jenkins-node' }
 
     stages {
-        stage('Initial Checks') {
+        stage('Create temporary environment for the pipeline') {
             steps {
-                echo "Check that 'openSUSE/MU/${mu_version}' branch exists at https://github.com/openSUSE/salt"
-                sh "curl -I --fail https://codeload.github.com/openSUSE/salt/tar.gz/openSUSE/MU/${mu_version}"
-
-                echo "Check that 'MU/${mu_version}' branch exists at https://github.com/openSUSE/salt-packaging"
-                sh "curl -I --fail https://codeload.github.com/openSUSE/salt-packaging/tar.gz/MU/${mu_version}"
-
-                echo "Check that 'products:testing' and 'products:testing:debian' are not set to MU branches"
-                sh "! curl https://build.opensuse.org/package/view_file/systemsmanagement:saltstack:products:testing/salt/_service?expand=1 | grep MU/${mu_version}"
-                sh "! curl https://build.opensuse.org/package/view_file/systemsmanagement:saltstack:products:testing:debian/salt/_service?expand=1 | grep MU/${mu_version}"
-
-                echo "Check the source tarball is properly named to salt_${salt_version}.orig.tar.gz in 'products:testing:debian'"
-                sh "curl https://build.opensuse.org/package/view_file/systemsmanagement:saltstack:products:testing:debian/salt/_service?expand=0 | grep salt_${salt_version}.orig.tar.g"
+                sh "mkdir /tmp/salt-promote-pipeline-env || true"
             }
         }
 
-        stage('Create temporary OBS environment') {
-            steps {
-                sh "mkdir /tmp/salt-promote-pipeline-env || true"
+        stage('Initial check and MU branches preparations') {
+	    steps {
+                script {
+                    echo "Check that 'openSUSE/MU/${mu_version}' branch exists at https://github.com/openSUSE/salt"
+                    salt_mu_branch = sh(script: "curl -I --fail https://codeload.github.com/openSUSE/salt/tar.gz/openSUSE/MU/${mu_version}", returnStatus: true)
+                    echo "Check that 'MU/${mu_version}' branch exists at https://github.com/openSUSE/salt-packaging"
+                    salt_packaging_mu_branch = sh(script: "curl -I --fail https://codeload.github.com/openSUSE/salt-packaging/tar.gz/MU/${mu_version}", returnStatus: true)
+
+                    dir('/tmp/salt-promote-pipeline-env') {
+                        if (salt_mu_branch != 0 || salt_packaging_mu_branch != 0) {
+                            echo "MU branches do not exist. Creating them"
+                            sh "git clone --branch openSUSE/release/${salt_version} --depth 1 https://github.com/openSUSE/salt"
+                            dir('/tmp/salt-promote-pipeline-env/salt') {
+                                sh "git checkout -b openSUSE/MU/${mu_version}"
+                                sh "git push origin openSUSE/MU/${mu_version}"
+                            }
+                            echo "Successfully created and pushed 'openSUSE/MU/${mu_version}' branch to 'openSUSE/salt' repository"
+                            sh "git clone --branch release/${salt_version} --depth 1 https://github.com/openSUSE/salt-packaging"
+                            dir('/tmp/salt-promote-pipeline-env/salt-packaging') {
+                                sh "git checkout -b MU/${mu_version}"
+                                sh "git push origin MU/${mu_version}"
+                            }
+                            echo "Successfully created and pushed 'MU/${mu_version}' branch to 'openSUSE/salt-packaging' repository"
+                        }
+                        else {
+                            if (params.recreate_salt_mu_branches) {
+                                // Forcing recreation of MU branches
+                                echo "The MU branches already exist, but pipeline was set to recreate them"
+                                sh "git clone --branch openSUSE/release/${salt_version} --depth 1 https://github.com/openSUSE/salt"
+                                dir('/tmp/salt-promote-pipeline-env/salt') {
+                                    sh "git checkout -b openSUSE/MU/${mu_version}"
+                                    sh "git push -f origin openSUSE/MU/${mu_version}"
+                                }
+                                echo "Successfully recreated and pushed 'openSUSE/MU/${mu_version}' branch to 'openSUSE/salt' repository"
+                                sh "git clone --branch release/${salt_version} --depth 1 https://github.com/openSUSE/salt-packaging"
+                                dir('/tmp/salt-promote-pipeline-env/salt-packaging') {
+                                    sh "git checkout -b MU/${mu_version}"
+                                    sh "git push -f origin MU/${mu_version}"
+                                }
+                                echo "Successfully recreated and pushed 'MU/${mu_version}' branch to 'openSUSE/salt-packaging' repository"
+                            }
+                            else {
+                                error("The MU branches were already created. Default promotion is not possible. Exiting.")
+                            }
+                        }
+                        sh "rm salt -rf && rm salt-packaging -rf"
+                    }
+
+                    echo "Check that 'products:testing' and 'products:testing:debian' are not set to MU branches"
+                    sh "! curl https://build.opensuse.org/package/view_file/systemsmanagement:saltstack:products:testing/salt/_service?expand=1 | grep MU/${mu_version}"
+                    sh "! curl https://build.opensuse.org/package/view_file/systemsmanagement:saltstack:products:testing:debian/salt/_service?expand=1 | grep MU/${mu_version}"
+
+                    echo "Check the source tarball is properly named to salt_${salt_version}.orig.tar.gz in 'products:testing:debian'"
+                    sh "curl https://build.opensuse.org/package/view_file/systemsmanagement:saltstack:products:testing:debian/salt/_service?expand=0 | grep salt_${salt_version}.orig.tar.gz"
+                }
             }
         }
 
         stage('Promote Salt testing RPM packages') {
             steps {
                 echo 'Promote Salt testing packages from "products:testing" to "products"'
-                sh "python3 promote_packages.py -s systemsmanagement:saltstack:products:testing -t systemsmanagement:saltstack:products"
-                sh "python3 promote_packages.py -s systemsmanagement:saltstack:products:old:testing -t systemsmanagement:saltstack:products:old"
+                sh "python3 promote_packages.py -s systemsmanagement:saltstack:products:testing -t systemsmanagement:saltstack:products packages"
+                sh "python3 promote_packages.py -s systemsmanagement:saltstack:products:old:testing -t systemsmanagement:saltstack:products:old packages"
             }
         }
 
@@ -60,11 +102,15 @@ pipeline {
                         sh "osc service disabledrun || true"
                         sh "osc add salt_${salt_version}.orig.tar.gz"
                         sh "osc commit -m 'Disable services and temporary add tarball before promoting'"
+                    }
+		}
 
-                        echo 'Promote "products:testing:debian" packages'
-                        sh "osc copypac --keep-link systemsmanagement:saltstack:products:testing:debian salt systemsmanagement:saltstack:products:debian"
-                        sh "python3 promote_packages.py -s systemsmanagement:saltstack:products:testing:debian -t systemsmanagement:saltstack:products:debian --excluded salt"
+                echo 'Promote "products:testing:debian" packages'
+                sh "osc copypac --keep-link systemsmanagement:saltstack:products:testing:debian salt systemsmanagement:saltstack:products:debian"
+                sh "python3 promote_packages.py -s systemsmanagement:saltstack:products:testing:debian -t systemsmanagement:saltstack:products:debian --exclude salt packages"
 
+                dir('/tmp/salt-promote-pipeline-env') {
+                    dir('/tmp/salt-promote-pipeline-env/systemsmanagement:saltstack:products:testing:debian/salt') {
                         echo 'Re-enable services in "products:testing:debian"'
                         sh "cp _service.backup _service"
                         sh "osc rm salt_${salt_version}.orig.tar.gz"
@@ -78,7 +124,7 @@ pipeline {
 
     post {
         always {
-            echo 'Remove OBS environment at /tmp/salt-promote-pipeline-env'
+            echo 'Remove temporary environment at /tmp/salt-promote-pipeline-env'
             sh "rm /tmp/salt-promote-pipeline-env -rf || true"
         }
     }

--- a/Jenkinsfile_promote_salt_packages
+++ b/Jenkinsfile_promote_salt_packages
@@ -42,16 +42,8 @@ pipeline {
         stage('Promote Salt testing RPM packages') {
             steps {
                 echo 'Promote Salt testing packages from "products:testing" to "products"'
-                sh "osc copypac systemsmanagement:saltstack:products:testing salt systemsmanagement:saltstack:products"
-                sh "osc copypac systemsmanagement:saltstack:products:testing python-contextvars systemsmanagement:saltstack:products"
-                sh "osc copypac systemsmanagement:saltstack:products:testing python3-contextvars systemsmanagement:saltstack:products"
-                sh "osc copypac systemsmanagement:saltstack:products:testing python-immutables systemsmanagement:saltstack:products"
-                sh "osc copypac systemsmanagement:saltstack:products:testing python3-immutables systemsmanagement:saltstack:products"
-                sh "osc copypac systemsmanagement:saltstack:products:testing py26-compat-salt systemsmanagement:saltstack:products"
-                sh "osc copypac systemsmanagement:saltstack:products:testing py26-compat-tornado systemsmanagement:saltstack:products"
-                sh "osc copypac systemsmanagement:saltstack:products:testing py26-compat-msgpack-python systemsmanagement:saltstack:products"
-                sh "osc copypac systemsmanagement:saltstack:products:testing py27-compat-salt systemsmanagement:saltstack:products"
-                sh "osc copypac systemsmanagement:saltstack:products:old:testing salt systemsmanagement:saltstack:products:old"
+                sh "python3 promote_packages.py -s systemsmanagement:saltstack:products:testing -t systemsmanagement:saltstack:products"
+                sh "python3 promote_packages.py -s systemsmanagement:saltstack:products:old:testing -t systemsmanagement:saltstack:products:old"
             }
         }
 
@@ -71,10 +63,7 @@ pipeline {
 
                         echo 'Promote "products:testing:debian" packages'
                         sh "osc copypac --keep-link systemsmanagement:saltstack:products:testing:debian salt systemsmanagement:saltstack:products:debian"
-                        sh "osc copypac systemsmanagement:saltstack:products:testing:debian python3-contextvars systemsmanagement:saltstack:products:debian"
-                        sh "osc copypac systemsmanagement:saltstack:products:testing:debian python3-immutables systemsmanagement:saltstack:products:debian"
-                        sh "osc copypac systemsmanagement:saltstack:products:testing:debian python3-zmq systemsmanagement:saltstack:products:debian"
-                        sh "osc copypac systemsmanagement:saltstack:products:testing:debian python3-gnupg systemsmanagement:saltstack:products:debian"
+                        sh "python3 promote_packages.py -s systemsmanagement:saltstack:products:testing:debian -t systemsmanagement:saltstack:products:debian --excluded salt"
 
                         echo 'Re-enable services in "products:testing:debian"'
                         sh "cp _service.backup _service"

--- a/Jenkinsfile_promote_salt_packages
+++ b/Jenkinsfile_promote_salt_packages
@@ -36,13 +36,13 @@ pipeline {
                             echo "MU branches do not exist. Creating them"
                             sh "git clone --branch openSUSE/release/${salt_version} --depth 1 https://github.com/openSUSE/salt"
                             dir('/tmp/salt-promote-pipeline-env/salt') {
-                                sh "git checkout -b openSUSE/MU/${mu_version}"
+                                sh "git switch --create openSUSE/MU/${mu_version}"
                                 sh "git push origin openSUSE/MU/${mu_version}"
                             }
                             echo "Successfully created and pushed 'openSUSE/MU/${mu_version}' branch to 'openSUSE/salt' repository"
                             sh "git clone --branch release/${salt_version} --depth 1 https://github.com/openSUSE/salt-packaging"
                             dir('/tmp/salt-promote-pipeline-env/salt-packaging') {
-                                sh "git checkout -b MU/${mu_version}"
+                                sh "git switch --create MU/${mu_version}"
                                 sh "git push origin MU/${mu_version}"
                             }
                             echo "Successfully created and pushed 'MU/${mu_version}' branch to 'openSUSE/salt-packaging' repository"
@@ -53,14 +53,14 @@ pipeline {
                                 echo "The MU branches already exist, but pipeline was set to recreate them"
                                 sh "git clone --branch openSUSE/release/${salt_version} --depth 1 https://github.com/openSUSE/salt"
                                 dir('/tmp/salt-promote-pipeline-env/salt') {
-                                    sh "git checkout -b openSUSE/MU/${mu_version}"
-                                    sh "git push -f origin openSUSE/MU/${mu_version}"
+                                    sh "git switch --create openSUSE/MU/${mu_version}"
+                                    sh "git push --force-with-lease origin openSUSE/MU/${mu_version}"
                                 }
                                 echo "Successfully recreated and pushed 'openSUSE/MU/${mu_version}' branch to 'openSUSE/salt' repository"
                                 sh "git clone --branch release/${salt_version} --depth 1 https://github.com/openSUSE/salt-packaging"
                                 dir('/tmp/salt-promote-pipeline-env/salt-packaging') {
-                                    sh "git checkout -b MU/${mu_version}"
-                                    sh "git push -f origin MU/${mu_version}"
+                                    sh "git switch --create MU/${mu_version}"
+                                    sh "git push --force-with-lease origin MU/${mu_version}"
                                 }
                                 echo "Successfully recreated and pushed 'MU/${mu_version}' branch to 'openSUSE/salt-packaging' repository"
                             }
@@ -85,7 +85,6 @@ pipeline {
             steps {
                 echo 'Promote Salt testing packages from "products:testing" to "products"'
                 sh "python3 promote_packages.py -s systemsmanagement:saltstack:products:testing -t systemsmanagement:saltstack:products packages"
-                sh "python3 promote_packages.py -s systemsmanagement:saltstack:products:old:testing -t systemsmanagement:saltstack:products:old packages"
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
 # salt-package-promote-obs
 
-This repository tracks the Jenkins jobs that we use at SUSE to promote the Salt packages used in our products
+This repository tracks the Jenkins pipelines, and scripts that we use at SUSE to promote the Salt packages used in our products.
+
+## Jenkinsfile_promote_salt_packages
+
+This pipeline takes care of promoting the classic Salt packages and dependencies at [OBS](https://build.opensuse.org/):
+
+- [systemsmanagement:saltstack:products:testing](https://build.opensuse.org/project/show/systemsmanagement:saltstack:products:testing) -> [systemsmanagement:saltstack:products](https://build.opensuse.org/project/show/systemsmanagement:saltstack:products)
+- [systemsmanagement:saltstack:products:testing:debian](https://build.opensuse.org/project/show/systemsmanagement:saltstack:products:testing:debian) -> [systemsmanagement:saltstack:products:debian](https://build.opensuse.org/project/show/systemsmanagement:saltstack:products:debian)
+
+## Jenkinsfile_promote_salt_bundle_packages
+
+This pipeline takes care of promoting the Salt Bundle package (venv-salt-minion) and its dependencies:
+
+- [systemsmanagement:saltstack:bundle:testing](https://build.opensuse.org/project/show/systemsmanagement:saltstack:bundle:testing) -> [systemsmanagement:saltstack:bundle](https://build.opensuse.org/project/show/systemsmanagement:saltstack:bundle)
+- Packages in subprojects
+- Project Configs in subprojects
+
+## promote_packages.py
+
+This script is used by the pipelines to take care of the different stages of the promotion.
+
+### Getting started:
+
+```console
+# pip3 install -r requirements.txt
+# python3 promote_packages.py --help
+```

--- a/promote_packages.py
+++ b/promote_packages.py
@@ -21,6 +21,9 @@ from osctiny.extensions.packages import Package
 from osctiny.extensions.projects import Project
 
 
+API_DEFAULT = "https://api.opensuse.org"
+
+
 def copy_packages(client, src, dst, subproject=None, exclude_packages=None):
     pkg_handler = Package(client)
     if subproject is not None:
@@ -86,9 +89,7 @@ def set_project_config(client, prj, config):
 def has_link(client, project, package) -> bool:
     pkg_handler = Package(client)
     pkg_files = pkg_handler.get_files(project, package)
-    linkinfo = etree.fromstring(etree.tostring(pkg_files).decode("utf-8")).find(
-        "linkinfo"
-    )
+    linkinfo = pkg_files.find("linkinfo")
     return linkinfo is not None
 
 
@@ -97,8 +98,8 @@ if __name__ == "__main__":
     parser.add_argument("-s", "--source", dest="src", help="Source Project")
     parser.add_argument("-t", "--target", dest="dst", help="Target Project")
     parser.add_argument(
-        "-A", "--apiurl", dest="url", default="https://api.opensuse.org",
-        help="URL to Build Service API"
+        "-A", "--apiurl", dest="url", default=API_DEFAULT,
+        help=f"URL to Build Service API. (Default: {API_DEFAULT})",
     )
     parser.add_argument(
         "--exclude", dest="exclude_packages", action="append", metavar="PACKAGE_TO_EXCLUDE"

--- a/promote_packages.py
+++ b/promote_packages.py
@@ -11,90 +11,152 @@ configuration from source to destination subproject.
 """
 
 import sys
+from argparse import ArgumentParser
 from difflib import unified_diff
 from traceback import format_exc
-from subprocess import run,CalledProcessError, PIPE
+from subprocess import run, CalledProcessError, PIPE
 from lxml import etree
 from osctiny import Osc
 from osctiny.extensions.packages import Package
 from osctiny.extensions.projects import Project
 
-def copy_packages(client, src, dst, subproject=None):
+
+def copy_packages(client, src, dst, subproject=None, exclude_packages=None):
     pkg_handler = Package(client)
     if subproject is not None:
         src = src + ":" + subproject
         dst = dst + ":" + subproject
+
+    if exclude_packages is None:
+        exclude_packages = []
 
     packages_list = pkg_handler.get_list(project=src)
     for package in packages_list.iter():
         package_name = package.attrib.get("name")
         # Only copypac the packages that are not linked to other package.
         # Packages with no link should be the ones that we mainain.
-        if package_name is not None and not has_link(client, src, package_name):
+        if (
+            package_name is not None
+            and package_name not in exclude_packages
+            and not has_link(client, src, package_name)
+        ):
             try:
                 result = get_diff(src, dst, package_name)
-                print("###################################################################", flush=True)
+                print(
+                    "###################################################################",
+                    flush=True,
+                )
                 print(f"Diff for {package_name}:\n {result}", flush=True)
-                print("###################################################################", flush=True)
+                print(
+                    "###################################################################",
+                    flush=True,
+                )
                 if result != "":
                     print(f"Copying {package_name} from {src} to {dst}\n", flush=True)
                     run(["osc", "copypac", src, package_name, dst], check=True)
             except CalledProcessError:
                 print(f"Could not copypac {package_name}\n", flush=True)
-                print(format_exc(),flush=True)
+                print(format_exc(), flush=True)
                 sys.exit(1)
 
+
 def get_diff(src, dst, pkgname) -> str:
-    result = run(["osc", "rdiff", dst, pkgname, src], check=True, stdout=PIPE, stderr=PIPE)
+    result = run(
+        ["osc", "rdiff", dst, pkgname, src], check=True, stdout=PIPE, stderr=PIPE
+    )
     return result.stdout.decode("utf-8")
+
 
 def get_subprojects(client, project_name) -> list:
     prefix = project_name + ":"
     root = client.search.project("starts-with(@name,'" + prefix + "')")
     return [p.attrib["name"] for p in root.findall("project")]
 
+
 def get_project_config(client, project_name) -> str:
     project_handler = Project(client)
     return project_handler.get_config(project_name)
+
 
 def set_project_config(client, prj, config):
     project_handler = Project(client)
     project_handler.set_config(prj, config=config)
 
+
 def has_link(client, project, package) -> bool:
     pkg_handler = Package(client)
-    pkg_files = pkg_handler.get_files(project,package)
-    linkinfo = etree.fromstring(etree.tostring(pkg_files).decode('utf-8')).find("linkinfo")
+    pkg_files = pkg_handler.get_files(project, package)
+    linkinfo = etree.fromstring(etree.tostring(pkg_files).decode("utf-8")).find(
+        "linkinfo"
+    )
     return linkinfo is not None
 
+
 if __name__ == "__main__":
-    osc = Osc(url="https://api.opensuse.org/")
+    parser = ArgumentParser()
+    parser.add_argument("-s", "--source", dest="src", help="Source Project")
+    parser.add_argument("-t", "--target", dest="dst", help="Target Project")
+    parser.add_argument(
+        "-A", "--apiurl", dest="url", default="https://api.opensuse.org",
+        help="URL to Build Service API"
+    )
+    parser.add_argument(
+        "--exclude", dest="exclude_packages", action="append", metavar="PACKAGE_TO_EXCLUDE"
+    )
+    parser.add_argument(
+        "--exclude-subproject", dest="exclude_subproject", action="append", metavar="SUBPROJECT_TO_EXCLUDE"
+    )
 
-    BASE_SRC = sys.argv[1]
-    BASE_DST = sys.argv[2]
+    commands = parser.add_subparsers(dest="action", title='Available actions', required=True)
+    commands.add_parser('packages', help="Promote packages from Source to Target projects")
+    commands.add_parser('subprojects', help="Promote packages inside subprojects")
+    commands.add_parser('projectconfigs', help="Promote project configs for subprojects")
+    commands.add_parser('all', help="Perform all the actions")
 
-    copy_packages(osc, BASE_SRC, BASE_DST)
+    args = parser.parse_args()
 
-    subprojects_src = get_subprojects(osc, BASE_SRC)
-    subprojects_dst = get_subprojects(osc, BASE_DST)
+    osc = Osc(url=args.url)
 
-    for subproject_src in subprojects_src:
-        sp_name = subproject_src[len(BASE_SRC) + 1:]
-        subproject_src = BASE_SRC + ":" + sp_name
-        subproject_dst = BASE_DST + ":" + sp_name
+    BASE_SRC = args.src
+    BASE_DST = args.dst
+    exclude = args.exclude_packages
+    exclude_subprojects = args.exclude_subproject if args.exclude_subproject is not None else []
 
-        if subproject_dst in subprojects_dst:
-            copy_packages(osc, BASE_SRC, BASE_DST, sp_name)
+    if args.action in ["packages", "all"]:
+        copy_packages(osc, BASE_SRC, BASE_DST, exclude_packages=exclude)
 
-            cfg_src = get_project_config(osc, subproject_src)
-            cfg_dst = get_project_config(osc, subproject_dst)
-            print("###################################################################", flush=True)
-            print(f"Configuration diff for {subproject_src} and {subproject_dst}\n", flush=True)
-            for line in unified_diff(cfg_src.splitlines(), cfg_dst.splitlines()):
-                print(line, flush=True)
-            print("###################################################################", flush=True)
+    if args.action in ["subprojects", "projectconfigs", "all"]:
+        subprojects_src = get_subprojects(osc, BASE_SRC)
+        subprojects_dst = get_subprojects(osc, BASE_DST)
 
-            set_project_config(osc, BASE_DST + ":" + sp_name, cfg_src)
-        else:
-            print(f"The project {subproject_dst} does not exist.\n", flush=True)
-            
+        for subproject_src in subprojects_src:
+            if subproject_src in exclude_subprojects:
+                continue
+            sp_name = subproject_src[len(BASE_SRC) + 1 :]
+            subproject_src = BASE_SRC + ":" + sp_name
+            subproject_dst = BASE_DST + ":" + sp_name
+            if subproject_dst in subprojects_dst:
+                if args.action in ["subprojects", "all"]:
+                    copy_packages(osc, BASE_SRC, BASE_DST, sp_name, exclude)
+
+                if args.action in ["projectconfigs", "all"]:
+                    cfg_src = get_project_config(osc, subproject_src)
+                    cfg_dst = get_project_config(osc, subproject_dst)
+                    print(
+                        "###################################################################",
+                        flush=True,
+                    )
+                    print(
+                        f"Configuration diff for {subproject_src} and {subproject_dst}\n",
+                        flush=True,
+                    )
+                    for line in unified_diff(cfg_src.splitlines(), cfg_dst.splitlines()):
+                        print(line, flush=True)
+                    print(
+                        "###################################################################",
+                        flush=True,
+                    )
+
+                    set_project_config(osc, BASE_DST + ":" + sp_name, cfg_src)
+            else:
+                print(f"The project {subproject_dst} does not exist.\n", flush=True)

--- a/promote_packages.py
+++ b/promote_packages.py
@@ -107,7 +107,8 @@ if __name__ == "__main__":
         "--exclude-subproject", dest="exclude_subproject", action="append", metavar="SUBPROJECT_TO_EXCLUDE"
     )
 
-    commands = parser.add_subparsers(dest="action", title='Available actions', required=True)
+    commands = parser.add_subparsers(dest="action", title='Available actions')
+    commands.required = True
     commands.add_parser('packages', help="Promote packages from Source to Target projects")
     commands.add_parser('subprojects', help="Promote packages inside subprojects")
     commands.add_parser('projectconfigs', help="Promote project configs for subprojects")

--- a/promote_packages.py
+++ b/promote_packages.py
@@ -46,16 +46,16 @@ def copy_packages(client, src, dst, subproject=None, exclude_packages=None):
                     "###################################################################",
                     flush=True,
                 )
-                print(f"Diff for {package_name}:\n {result}", flush=True)
+                print(f"Diff for '{package_name}' package from '{src}' to '{dst}':\n {result}", flush=True)
                 print(
                     "###################################################################",
                     flush=True,
                 )
                 if result != "":
-                    print(f"Copying {package_name} from {src} to {dst}\n", flush=True)
+                    print(f"Copying '{package_name}' from '{src}' to '{dst}'\n", flush=True)
                     run(["osc", "copypac", src, package_name, dst], check=True)
             except CalledProcessError:
-                print(f"Could not copypac {package_name}\n", flush=True)
+                print(f"Could not copypac '{package_name}'\n", flush=True)
                 print(format_exc(), flush=True)
                 sys.exit(1)
 
@@ -147,7 +147,7 @@ if __name__ == "__main__":
                         flush=True,
                     )
                     print(
-                        f"Configuration diff for {subproject_src} and {subproject_dst}\n",
+                        f"Configuration diff for '{subproject_src}' and '{subproject_dst}':\n",
                         flush=True,
                     )
                     for line in unified_diff(cfg_src.splitlines(), cfg_dst.splitlines()):
@@ -159,4 +159,4 @@ if __name__ == "__main__":
 
                     set_project_config(osc, BASE_DST + ":" + sp_name, cfg_src)
             else:
-                print(f"The project {subproject_dst} does not exist.\n", flush=True)
+                print(f"The project '{subproject_dst}' does not exist.\n", flush=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+osc-tiny
+cached-property
+lxml


### PR DESCRIPTION
In our efforts to improve and reduce complexity of our Salt release process, this PR makes the following improvements:

- Promotion script:
    -  Improve promotion script for it to be able to exclude packages and subprojects to copy.
    -  Allow execution of individual stages.
- Salt package promotion:
  - New parameter -> `recreate_mu_branches` to force MU branches recreation.
  - MU branches are now created by pipeline if they don't exist. If they already exist pipeline will fail by default unless using `recreate_mu_branches` parameter.
- Salt Bundle promotion:
  - Execute different stages separately.
- Cosmetic changes on displayed output.
