### PR TITLE
Avoid rejection due stale info when doing "git push --force-with-lease"

### DIFF
--- a/Jenkinsfile_promote_salt_packages
+++ b/Jenkinsfile_promote_salt_packages
@@ -51,13 +51,13 @@ pipeline {
                             if (params.recreate_salt_mu_branches) {
                                 // Forcing recreation of MU branches
                                 echo "The MU branches already exist, but pipeline was set to recreate them"
-                                sh "git clone --branch openSUSE/release/${salt_version} --depth 1 https://github.com/openSUSE/salt"
+                                sh "git clone --branch openSUSE/release/${salt_version} https://github.com/openSUSE/salt"
                                 dir('/tmp/salt-promote-pipeline-env/salt') {
                                     sh "git switch --create openSUSE/MU/${mu_version}"
                                     sh "git push --force-with-lease origin openSUSE/MU/${mu_version}"
                                 }
                                 echo "Successfully recreated and pushed 'openSUSE/MU/${mu_version}' branch to 'openSUSE/salt' repository"
-                                sh "git clone --branch release/${salt_version} --depth 1 https://github.com/openSUSE/salt-packaging"
+                                sh "git clone --branch release/${salt_version} https://github.com/openSUSE/salt-packaging"
                                 dir('/tmp/salt-promote-pipeline-env/salt-packaging') {
                                     sh "git switch --create MU/${mu_version}"
                                     sh "git push --force-with-lease origin MU/${mu_version}"


### PR DESCRIPTION
If we clone a branch with `--depth 1` then git does not have enough info to properly perform a `git push --force-with-lease`, resulting in a rejection:

```console
+ git clone --branch openSUSE/release/3006.0 --depth 1 https://github.com/openSUSE/salt
Cloning into 'salt'...
[Pipeline] dir
Running in /tmp/salt-promote-pipeline-env/salt
[Pipeline] {
[Pipeline] sh
+ git switch --create openSUSE/MU/4.3.8
Switched to a new branch 'openSUSE/MU/4.3.8'
[Pipeline] sh
+ git push --force-with-lease origin openSUSE/MU/4.3.8
To https://github.com/openSUSE/salt
 ! [rejected]        openSUSE/MU/4.3.8 -> openSUSE/MU/4.3.8 (stale info)
error: failed to push some refs to 'https://github.com/openSUSE/salt'
```

This PR simply remove the `depth` argument when recreating the MU branches, so we can successfully run `git push --force-with-lease`.