### PR TITLE
Fix URLs to get content of "_service" files after changes in OBS

### DIFF
--- a/Jenkinsfile_promote_salt_packages
+++ b/Jenkinsfile_promote_salt_packages
@@ -72,11 +72,11 @@ pipeline {
                     }
 
                     echo "Check that 'products:testing' and 'products:testing:debian' are not set to MU branches"
-                    sh "! curl https://build.opensuse.org/package/view_file/systemsmanagement:saltstack:products:testing/salt/_service?expand=1 | grep MU/${mu_version}"
-                    sh "! curl https://build.opensuse.org/package/view_file/systemsmanagement:saltstack:products:testing:debian/salt/_service?expand=1 | grep MU/${mu_version}"
+                    sh "! curl https://build.opensuse.org/projects/systemsmanagement:saltstack:products:testing/packages/salt/files/_service?expand=1 | grep MU/${mu_version}"
+                    sh "! curl https://build.opensuse.org/projects/systemsmanagement:saltstack:products:testing:debian/packages/salt/files/_service?expand=1 | grep MU/${mu_version}"
 
                     echo "Check the source tarball is properly named to salt_${salt_version}.orig.tar.gz in 'products:testing:debian'"
-                    sh "curl https://build.opensuse.org/package/view_file/systemsmanagement:saltstack:products:testing:debian/salt/_service?expand=0 | grep salt_${salt_version}.orig.tar.gz"
+                    sh "curl https://build.opensuse.org/projects/systemsmanagement:saltstack:products:testing:debian/packages/salt/files/_service?expand=0 | grep salt_${salt_version}.orig.tar.gz"
                 }
             }
         }


### PR DESCRIPTION
It seems OBS changed some URLs and now pipeline is failing as a "redirect" is found and not the expected content.

```
# curl -vvv https://build.opensuse.org/package/view_file/systemsmanagement:saltstack:products:testing/salt/_service
...
< location: https://build.opensuse.org/projects/systemsmanagement:saltstack:products:testing/packages/salt/files/_service
< content-length: 175
< status: 301 Moved Permanently
< content-type: text/html
< 
* Connection #0 to host build.opensuse.org left intact
<html><body>You are being <a href="https://build.opensuse.org/projects/systemsmanagement:saltstack:products:testing/packages/salt/files/_service">redirected</a>.</body></html>
```

This PR simply changes the URL to fetch the content of the `_service` files.